### PR TITLE
授業科目名および担当教員名を検索する際に大文字小文字の違いを無視する

### DIFF
--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -82,11 +82,11 @@ function matchesCampus(subject: Subject2, searchOptions: SearchOptions): boolean
 }
 
 function matchesSubjectName(subject: Subject2, searchOptions: SearchOptions): boolean {
-    return searchOptions.subjectName === "" || subject["授業科目名"].includes(searchOptions.subjectName);
+    return searchOptions.subjectName === "" || subject["授業科目名"].toLowerCase().includes(searchOptions.subjectName.toLowerCase());
 }
 
 function matchesTeacher(subject: Subject2, searchOptions: SearchOptions): boolean {
-    return searchOptions.teacher === "" || subject["担当教員名"].some(teacher => teacher.includes(searchOptions.teacher));
+    return searchOptions.teacher === "" || subject["担当教員名"].some(teacher => teacher.toLowerCase().includes(searchOptions.teacher.toLowerCase()));
 }
 
 function matchesKamokuKubun(subject: Subject2, searchOptions: SearchOptions): boolean {


### PR DESCRIPTION
## 概要

授業科目名および担当教員名で、アルファベットの大小が違っていてもマッチするようにします。

<img width="682" alt="スクリーンショット 2024-09-24 11 57 27" src="https://github.com/user-attachments/assets/7d6373f5-64ba-40f6-bd86-64cb9126a797">

## 理由

特に英語の名前の講義・先生など、大文字小文字を人間の側で気をつけるのが手間がかかる。
この手法にするデメリットは特に思いつきませんでしたが、何かあれば！