### PR TITLE
feat: データ年度と取得日をmanifest連動で表示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,13 @@ import Timetable from './components/Timetable';
 import { BookmarkProvider } from './contexts/BookmarkContext';
 import { initialSearchOptions } from './search/';
 import { initializeSubject } from './subject';
+import { subjectDataManifest } from './subject/activeSubjectData';
 import { SearchOptions } from './types/search';
+
+const formatRetrievedAt = (retrievedAt: string) => {
+  const [year, month, day] = retrievedAt.split('-');
+  return `${year}年${Number(month)}月${Number(day)}日`;
+};
 
 function App() {
   initializeSubject();
@@ -152,7 +158,9 @@ function App() {
               >
                 広島大学シラバス
               </Link>
-              から取得したものを使用しています。（最終データ更新日：2026年4月7日）
+              から取得したものを使用しています。（
+              {subjectDataManifest.academicYear}・最終データ取得日：
+              {formatRetrievedAt(subjectDataManifest.retrievedAt)}）
             </Alert>
           </Box>
 


### PR DESCRIPTION
## 概要

Issue #19の最後の完了条件として、シラバス案内にactiveデータの年度と取得日を表示します。

## 変更

- subjectDataManifestのacademicYearとretrievedAtを表示
- YYYY-MM-DDを文字列分解して日本語表記へ整形し、timezone依存を回避
- ハードコードされていた更新日を削除

## 検証

- pnpm exec eslint src/App.tsx
- pnpm exec tsc --noEmit
- pnpm prebuild（12,489件、2026年度、生成定数一致）
- pnpm exec prettier --check src/App.tsx
- pnpm exec vite build --outDir /private/tmp/momiji2-vite-build-issue19-03fc6d1
- git diff --check HEAD^ HEAD

Closes #19