### PR TITLE
fix: 科目データ初期化を起動時の1回に限定

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,14 +28,15 @@ import { initializeSubject } from './subject';
 import { subjectDataManifest } from './subject/activeSubjectData';
 import { SearchOptions } from './types/search';
 
+// Initialize subject data once when this module is evaluated, not on every render.
+initializeSubject();
+
 const formatRetrievedAt = (retrievedAt: string) => {
   const [year, month, day] = retrievedAt.split('-');
   return `${year}年${Number(month)}月${Number(day)}日`;
 };
 
 function App() {
-  initializeSubject();
-
   const [searchOptions, setSearchOptions] =
     useState<SearchOptions>(initialSearchOptions);
 


### PR DESCRIPTION
## 概要

Issue #25 / #69の調査で、React再renderごとに12,489件の科目初期化とフィルタ件数集計が再実行されていたため、module評価時の1回だけに限定します。

## 変更

- initializeSubjectをApp関数本体からmodule scopeへ移動
- UI、検索結果、データ、集計ロジックは変更なし

## 検証

- pnpm exec eslint src/App.tsx
- pnpm exec tsc --noEmit
- pnpm prebuild
- pnpm test:subject-constants（9 pass）
- pnpm exec prettier --check src/App.tsx
- pnpm exec vite build --outDir /private/tmp/momiji2-vite-build-issue25-3b48d4f
- git diff --check HEAD^ HEAD

Issue #25の主要因を除去します。ブラウザ実測前のためIssue自体は自動closeしません。