### PR TITLE
Pin pnpm for GitHub Pages deploys

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -20,10 +20,10 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8.15.9
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -21,10 +21,10 @@ jobs:
         node-version: '22'
 
     - name: Install pnpm
-      run: npm install -g pnpm
+      run: npm install -g pnpm@8.15.9
 
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm run build


### PR DESCRIPTION
## What changed

- pin pnpm 8.15.9 in both GitHub Pages deploy workflows
- install dependencies with --frozen-lockfile

## Root cause

Develop deploy run #141 installed the latest pnpm, which treated the repository's lockfile v6 as incompatible, resolved newer dependency versions, and then failed with ERR_PNPM_IGNORED_BUILDS for esbuild before the build step.

## Impact

Both develop and main deployments will use the pnpm major that matches the committed lockfile and fail instead of silently drifting from it.

## Validation

- parsed both workflow files with Ruby's standard YAML parser
- confirmed both workflows use pnpm@8.15.9 and --frozen-lockfile
- git diff --check

Fixes the deployment blocker discovered while validating #90.