### PR TITLE
Replace GitHub Pages deployment prefixes

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Preserve build output
+        run: |
+          rm -rf "$RUNNER_TEMP/momiji2-dist"
+          mkdir -p "$RUNNER_TEMP/momiji2-dist"
+          cp -R dist/. "$RUNNER_TEMP/momiji2-dist/"
+
       - name: Fetch and checkout gh-pages branch
         run: |
           git fetch origin gh-pages:gh-pages
@@ -41,9 +47,10 @@ jobs:
 
       - name: Commit and push changes
         run: |
-          mkdir -p dev
-          cp -r dist/* dev/
-          git add dev
+          rm -rf ./dev
+          mkdir -p ./dev
+          cp -R "$RUNNER_TEMP/momiji2-dist"/. ./dev/
+          git add -A dev
           git diff --staged --quiet || git commit -m "Deploy develop branch to /dev directory"
           git fetch origin gh-pages
           git push --force https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} gh-pages

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -29,12 +29,29 @@ jobs:
     - name: Build
       run: pnpm run build
 
-    - name: "DEBUG: show build output"
-      run: ls -R ./dist || echo "dist not found!"
+    - name: Preserve build output
+      run: |
+        rm -rf "$RUNNER_TEMP/momiji2-dist"
+        mkdir -p "$RUNNER_TEMP/momiji2-dist"
+        cp -R dist/. "$RUNNER_TEMP/momiji2-dist/"
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        personal_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        publish_dir: ./dist
-        keep_files: true
+    - name: Fetch and checkout gh-pages branch
+      run: |
+        git fetch origin gh-pages:gh-pages
+        git reset --hard HEAD
+        git checkout gh-pages
+
+    - name: Configure Git
+      run: |
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+    - name: Commit and push changes
+      run: |
+        find . -mindepth 1 -maxdepth 1 ! -name .git ! -name dev -exec rm -rf -- {} +
+        cp -R "$RUNNER_TEMP/momiji2-dist"/. ./
+        touch .nojekyll
+        git add -A
+        git diff --staged --quiet || git commit -m "Deploy main branch to root directory"
+        git fetch origin gh-pages
+        git push --force https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} gh-pages


### PR DESCRIPTION
## What changed

- develop deploy now replaces the entire dev prefix instead of accumulating hashed assets
- main deploy now replaces the root prefix while preserving dev
- build output is staged in RUNNER_TEMP before checking out gh-pages
- deleted files are included with git add -A

## Root cause

The gh-pages branch retained every historical hashed bundle. It reached about 1.96 GB tracked data (root 586 MB, dev 1.37 GB), producing a 259 MB Pages artifact and a 10-minute deployment timeout.

## Safety

- develop cleanup is limited to ./dev
- main cleanup is limited to root entries while explicitly preserving .git and dev
- existing pnpm 8.15.9 pin, frozen lockfile, token, and deploy destinations are unchanged

## Validation

- Ruby standard YAML parse
- shell block syntax checks
- requirement searches for prefix replacement and git add -A
- git diff --check