### PR TITLE
Issue #30: add deterministic syllabus generation diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:subject-constants": "node --test ./scripts/generate-subject-constants.test.mjs",
     "test:data-validator": "node --test ./scripts/validate-subject-data.test.mjs",
     "test:raw-subject-contract": "node --test ./scripts/raw-subject-contract.test.mjs",
+    "test:subject-diff": "node --test ./scripts/subject-diff.test.mjs",
     "lint": "eslint src --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,md,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,md,json}\"",

--- a/scripts/subject-diff.mjs
+++ b/scripts/subject-diff.mjs
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const rawPropertiesPath = new URL(
+  '../data/subjectRawProperties.json',
+  import.meta.url
+);
+export const requiredFields = JSON.parse(
+  await fs.readFile(rawPropertiesPath, 'utf8')
+);
+export const metadataFields = ['relative URL', '年度'];
+const requiredFieldSet = new Set(requiredFields);
+const metadataFieldSet = new Set(metadataFields);
+
+function validateYearData(data, label) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`${label} must be a JSON object keyed by lecture code.`);
+  }
+  const entries = Object.entries(data);
+  const years = new Set();
+  for (const [code, record] of entries) {
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      throw new Error(`${label} subject ${code} must be an object.`);
+    }
+    const fields = Object.keys(record);
+    if (
+      fields.length !== requiredFields.length ||
+      fields.some((field) => !requiredFieldSet.has(field))
+    ) {
+      throw new Error(
+        `${label} subject ${code} must have exactly the 19 raw fields.`
+      );
+    }
+    for (const field of requiredFields) {
+      if (!(field in record))
+        throw new Error(`${label} subject ${code} is missing field: ${field}`);
+      if (typeof record[field] !== 'string')
+        throw new Error(
+          `${label} subject ${code} field ${field} must be a string.`
+        );
+    }
+    if (record['講義コード'] !== code) {
+      throw new Error(
+        `${label} lecture code mismatch: key=${code}, field=${record['講義コード']}`
+      );
+    }
+    years.add(record['年度']);
+  }
+  if (years.size !== 1 || !/^\d{4}年度$/.test([...years][0] ?? '')) {
+    throw new Error(
+      `${label} must contain records from exactly one academic year.`
+    );
+  }
+  return { academicYear: [...years][0], records: data };
+}
+
+export function compareSubjectData(baseline, incoming) {
+  const base = validateYearData(baseline, 'baseline');
+  const next = validateYearData(incoming, 'incoming');
+  const codes = [
+    ...new Set([...Object.keys(base.records), ...Object.keys(next.records)]),
+  ].sort();
+  const added = [];
+  const removed = [];
+  const changed = [];
+  for (const code of codes) {
+    const before = base.records[code];
+    const after = next.records[code];
+    if (!before) {
+      added.push({ code, recordIdentity: `${next.academicYear}+${code}` });
+    } else if (!after) {
+      removed.push({ code, recordIdentity: `${base.academicYear}+${code}` });
+    } else {
+      const fields = requiredFields.filter(
+        (field) => before[field] !== after[field]
+      );
+      if (fields.length) {
+        changed.push({
+          code,
+          recordIdentity: {
+            baseline: `${base.academicYear}+${code}`,
+            incoming: `${next.academicYear}+${code}`,
+          },
+          fields: fields.map((field) => ({
+            field,
+            before: before[field],
+            after: after[field],
+            kind: metadataFieldSet.has(field) ? 'metadata' : 'content',
+          })),
+        });
+      }
+    }
+  }
+  return {
+    baseline: {
+      academicYear: base.academicYear,
+      recordCount: Object.keys(base.records).length,
+    },
+    incoming: {
+      academicYear: next.academicYear,
+      recordCount: Object.keys(next.records).length,
+    },
+    added,
+    removed,
+    changed,
+  };
+}
+
+export function serializeSubjectDiff(baseline, incoming) {
+  return `${JSON.stringify(compareSubjectData(baseline, incoming), null, 2)}\n`;
+}
+
+async function main() {
+  if (process.argv.length !== 4)
+    throw new Error(
+      'Usage: node scripts/subject-diff.mjs BASELINE.json INCOMING.json'
+    );
+  const [baselineText, incomingText] = await Promise.all([
+    fs.readFile(path.resolve(process.argv[2]), 'utf8'),
+    fs.readFile(path.resolve(process.argv[3]), 'utf8'),
+  ]);
+  process.stdout.write(
+    serializeSubjectDiff(JSON.parse(baselineText), JSON.parse(incomingText))
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/subject-diff.test.mjs
+++ b/scripts/subject-diff.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import {
+  compareSubjectData,
+  requiredFields,
+  serializeSubjectDiff,
+} from './subject-diff.mjs';
+
+const record = (code, year, overrides = {}) =>
+  Object.fromEntries(
+    requiredFields.map((field) => [
+      field,
+      overrides[field] ??
+        (field === '講義コード'
+          ? code
+          : field === '年度'
+            ? year
+            : `${field}-${code}`),
+    ])
+  );
+
+test('reports sorted added, removed, and raw changed fields', () => {
+  const result = compareSubjectData(
+    {
+      z: record('z', '2024年度'),
+      gone: record('gone', '2024年度'),
+      same: record('same', '2024年度'),
+    },
+    {
+      add: record('add', '2025年度'),
+      same: record('same', '2025年度', { メッセージ: 'changed' }),
+      z: record('z', '2025年度'),
+    }
+  );
+  assert.deepEqual(result.added, [
+    { code: 'add', recordIdentity: '2025年度+add' },
+  ]);
+  assert.deepEqual(result.removed, [
+    { code: 'gone', recordIdentity: '2024年度+gone' },
+  ]);
+  assert.deepEqual(
+    result.changed[0].fields.find((x) => x.field === '年度'),
+    { field: '年度', before: '2024年度', after: '2025年度', kind: 'metadata' }
+  );
+  assert.deepEqual(
+    result.changed[0].fields.find((x) => x.field === 'メッセージ'),
+    {
+      field: 'メッセージ',
+      before: 'メッセージ-same',
+      after: 'changed',
+      kind: 'content',
+    }
+  );
+});
+
+test('is byte-identical across order and preserves raw whitespace and Unicode differences', () => {
+  const before = record('x', '2024年度', {
+    メッセージ: '',
+    その他: 'が',
+  });
+  const after = Object.fromEntries(
+    [...requiredFields]
+      .reverse()
+      .map((field) => [
+        field,
+        field === '講義コード'
+          ? 'x'
+          : field === '年度'
+            ? '2025年度'
+            : field === 'メッセージ'
+              ? '  '
+              : before[field],
+      ])
+  );
+  after.その他 = 'か\u3099';
+  const one = serializeSubjectDiff({ x: before }, { x: after });
+  const two = serializeSubjectDiff(
+    { x: Object.fromEntries(Object.entries(before).reverse()) },
+    { x: Object.fromEntries(Object.entries(after).reverse()) }
+  );
+  assert.equal(one, two);
+  assert.ok(one.endsWith('\n'));
+  assert.deepEqual(
+    compareSubjectData({ x: before }, { x: after }).changed[0].fields.map(
+      (x) => x.field
+    ),
+    ['年度', 'メッセージ', 'その他']
+  );
+  assert.deepEqual(
+    compareSubjectData({ x: before }, { x: after }).changed[0].fields.find(
+      (x) => x.field === 'その他'
+    ),
+    { field: 'その他', before: 'が', after: 'か\u3099', kind: 'content' }
+  );
+});
+
+for (const name of [
+  'duplicate lecture-code alias',
+  'key/code mismatch',
+  'missing field',
+  'extra field',
+  'non-string field',
+  'mixed academic years',
+]) {
+  test(`rejects ${name}`, () => {
+    const good = { x: record('x', '2024年度') };
+    const bad = structuredClone(good);
+    if (name === 'duplicate lecture-code alias')
+      bad.y = record('x', '2024年度');
+    if (name === 'key/code mismatch') bad.x['講義コード'] = 'y';
+    if (name === 'missing field') delete bad.x['その他'];
+    if (name === 'extra field') bad.x.extra = 'x';
+    if (name === 'non-string field') bad.x['単位'] = 1;
+    if (name === 'mixed academic years') bad.y = record('y', '2025年度');
+    assert.throws(() => compareSubjectData(bad, good));
+  });
+}
+
+test('matches investigated real-data added and removed counts', async () => {
+  const root = process.cwd();
+  const data = async (file) =>
+    JSON.parse(await fs.readFile(path.join(root, 'data', file), 'utf8'));
+  const a = await compareSubjectData(
+    await data('subject_data_main_2024-04-05.json'),
+    await data('subject_details_main_2025-04-03.json')
+  );
+  const b = await compareSubjectData(
+    await data('subject_details_main_2025-04-03.json'),
+    await data('subject_details_main_2026-04-07.json')
+  );
+  assert.equal(a.added.length, 1535);
+  assert.equal(a.removed.length, 2093);
+  assert.equal(b.added.length, 2130);
+  assert.equal(b.removed.length, 1630);
+  assert.ok(a.changed.length > 0);
+  assert.ok(b.changed.length > 0);
+});


### PR DESCRIPTION
## What changed

- add a read-only `scripts/subject-diff.mjs` CLI for two validated yearly subject JSON files
- report lecture-code-level added, removed, and 19-field raw changes in deterministic order
- distinguish metadata fields (`年度`, `relative URL`) without suppressing them
- preserve whitespace and Unicode representation differences; no normalization in this first stage
- add 9 focused tests including real 2024→2025 and 2025→2026 counts

## Why

Issue #30 needs a mechanically verifiable diff foundation before deciding UI, history retention, or normalization rules. This stage does not modify active data, manifests, import behavior, or runtime UI.

## Verification

- `pnpm test:subject-diff` (9 passed)
- `pnpm test:raw-subject-contract` (3 passed)
- `pnpm test:data-validator` (7 passed)
- `pnpm test:update-guard` (6 passed)
- `pnpm test:import-harvester-generation` (14 passed)
- `pnpm exec tsc --noEmit`
- `pnpm prebuild` (12,489 records, constants current)
- targeted ESLint and Prettier
- `git diff --check`

Real-data counts:
- 2024→2025: added 1,535 / removed 2,093 / changed 10,454
- 2025→2026: added 2,130 / removed 1,630 / changed 10,359

Related: #30