### PR TITLE
#99 値集合の変化を非阻害の分析情報として扱う

### DIFF
--- a/scripts/import-harvester-generation.mjs
+++ b/scripts/import-harvester-generation.mjs
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 import { pathToFileURL } from 'url';
@@ -22,6 +22,37 @@ async function readJson(filePath, label) {
     return JSON.parse(await fs.readFile(filePath, 'utf8'));
   } catch (error) {
     throw new Error(`Invalid ${label} JSON: ${error.message}`);
+  }
+}
+
+function validateStructureReport(report, manifest, dataSha256) {
+  if (manifest.schemaVersion !== 1 || !manifest.structureReport) {
+    throw new Error(
+      'Harvester manifest must include a version 1 structure report.'
+    );
+  }
+  if (
+    !report ||
+    typeof report !== 'object' ||
+    Array.isArray(report) ||
+    report.schemaVersion !== 1 ||
+    report.academicYear !== manifest.academicYear ||
+    report.retrievedAt !== manifest.retrievedAt ||
+    report.source !== manifest.source ||
+    !report.subjectData ||
+    report.subjectData.dataFile !== manifest.dataFile ||
+    report.subjectData.sha256 !== dataSha256 ||
+    report.subjectData.subjectCount !== manifest.subjectCount ||
+    !report.structure ||
+    report.structure.subjectPageCount !== manifest.subjectCount ||
+    !Array.isArray(report.structure.unknownHeaders) ||
+    report.structure.unknownHeaders.length !== 0 ||
+    !Array.isArray(report.structure.missingHeaders) ||
+    report.structure.missingHeaders.length !== 0
+  ) {
+    throw new Error(
+      'Harvester structure report does not match the generation.'
+    );
   }
 }
 
@@ -182,9 +213,18 @@ export async function importHarvesterGeneration({
   const sourceDepartmentsPath = path.resolve(departmentsPath);
   const manifest = await readJson(sourceManifestPath, 'Harvester manifest');
   validateManifest(manifest);
+  if (manifest.schemaVersion !== 1 || !manifest.structureReport) {
+    throw new Error(
+      'Harvester manifest must include a version 1 structure report.'
+    );
+  }
   const sourceDataPath = path.resolve(
     path.dirname(sourceManifestPath),
     manifest.dataFile
+  );
+  const sourceStructurePath = path.resolve(
+    path.dirname(sourceManifestPath),
+    manifest.structureReport?.dataFile ?? ''
   );
   const destinationDataPath = path.resolve(
     destinationDataDir,
@@ -194,22 +234,46 @@ export async function importHarvesterGeneration({
     destinationDataDir,
     'department_constants.json'
   );
+  const destinationStructurePath = path.resolve(
+    destinationDataDir,
+    'subject_structure.json'
+  );
   const destinationManifestPath = path.resolve(
     destinationDataDir,
     'subjectDataManifest.json'
   );
   await assertDistinctInputPaths(
-    [sourceManifestPath, sourceDataPath, sourceDepartmentsPath],
-    [destinationDataPath, destinationDepartmentsPath, destinationManifestPath]
+    [
+      sourceManifestPath,
+      sourceDataPath,
+      sourceDepartmentsPath,
+      sourceStructurePath,
+    ],
+    [
+      destinationDataPath,
+      destinationDepartmentsPath,
+      destinationStructurePath,
+      destinationManifestPath,
+    ]
   );
 
-  const [dataBytes, departmentConstants] = await Promise.all([
-    fs.readFile(sourceDataPath),
-    readJson(sourceDepartmentsPath, 'Harvester department artifact'),
-  ]);
+  const [dataBytes, departmentConstants, structureBytes, structureReport] =
+    await Promise.all([
+      fs.readFile(sourceDataPath),
+      readJson(sourceDepartmentsPath, 'Harvester department artifact'),
+      fs.readFile(sourceStructurePath),
+      readJson(sourceStructurePath, 'Harvester structure report'),
+    ]);
   const { data, sha256 } = parseAndHashSubjectData(dataBytes);
   validateSubjectData(data, manifest);
   validateDepartmentConstants(departmentConstants, manifest, sha256);
+  const structureSha256 = createHash('sha256')
+    .update(structureBytes)
+    .digest('hex');
+  if (structureSha256 !== manifest.structureReport.sha256) {
+    throw new Error('Harvester structure report hash does not match manifest.');
+  }
+  validateStructureReport(structureReport, manifest, sha256);
   deriveSubjectConstants(data, departmentConstants, manifest, sha256);
 
   const updateGuard = await readJson(updateGuardPath, 'update guard config');
@@ -235,6 +299,7 @@ export async function importHarvesterGeneration({
     enforceGuard(guardReport, false, acceptReview);
     let existingData;
     let previousDepartments;
+    let previousStructure;
     try {
       existingData = await fs.readFile(destinationDataPath);
     } catch (error) {
@@ -245,6 +310,11 @@ export async function importHarvesterGeneration({
     } catch (error) {
       if (error.code !== 'ENOENT') throw error;
     }
+    try {
+      previousStructure = await fs.readFile(destinationStructurePath);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
     if (existingData && !existingData.equals(dataBytes)) {
       throw new Error(
         `Destination data collision for ${manifest.dataFile}: bytes differ.`
@@ -252,6 +322,7 @@ export async function importHarvesterGeneration({
     }
 
     let installedDepartments = false;
+    let installedStructure = false;
     let createdData = false;
     try {
       if (!existingData) {
@@ -263,11 +334,20 @@ export async function importHarvesterGeneration({
         `${JSON.stringify(departmentConstants, null, 2)}\n`
       );
       installedDepartments = true;
+      await replaceFile(destinationStructurePath, structureBytes);
+      installedStructure = true;
       await replaceFile(
         destinationManifestPath,
         `${JSON.stringify(manifest, null, 2)}\n`
       );
     } catch (error) {
+      if (installedStructure) {
+        if (previousStructure) {
+          await replaceFile(destinationStructurePath, previousStructure);
+        } else {
+          await fs.rm(destinationStructurePath, { force: true });
+        }
+      }
       if (installedDepartments) {
         if (previousDepartments) {
           await replaceFile(destinationDepartmentsPath, previousDepartments);

--- a/scripts/import-harvester-generation.mjs
+++ b/scripts/import-harvester-generation.mjs
@@ -119,7 +119,12 @@ async function evaluateDestinationGuard(destinationDataDir, incoming, config) {
     bytes = await fs.readFile(manifestPath);
   } catch (error) {
     if (error.code === 'ENOENT')
-      return { hardFailures: [], review: [], info: ['no baseline'] };
+      return {
+        hardFailures: [],
+        review: [],
+        analysis: [],
+        info: ['no baseline'],
+      };
     throw error;
   }
   let manifest;

--- a/scripts/import-harvester-generation.test.mjs
+++ b/scripts/import-harvester-generation.test.mjs
@@ -58,6 +58,7 @@ async function fixture(overrides = {}) {
   const dataFile = 'subject_details_main_2027-04-01_deadbeef.json';
   const dataBytes = Buffer.from(JSON.stringify(subjectData()), 'utf8');
   const manifest = {
+    schemaVersion: 1,
     dataFile,
     academicYear: '2027年度',
     retrievedAt: '2027-04-01',
@@ -82,12 +83,38 @@ async function fixture(overrides = {}) {
     },
     ...overrides.artifact,
   };
+  const structure = {
+    schemaVersion: 1,
+    academicYear: manifest.academicYear,
+    retrievedAt: manifest.retrievedAt,
+    source: manifest.source,
+    subjectData: {
+      dataFile: manifest.dataFile,
+      sha256,
+      subjectCount: manifest.subjectCount,
+    },
+    structure: {
+      subjectPageCount: manifest.subjectCount,
+      observedHeaders: fields.slice().sort(),
+      unknownHeaders: [],
+      missingHeaders: [],
+      headerPresence: {},
+    },
+    ...overrides.structure,
+  };
+  const structureBytes = Buffer.from(JSON.stringify(structure));
+  const structureFile = 'subject_structure_generation.json';
+  manifest.structureReport = {
+    dataFile: structureFile,
+    sha256: createHash('sha256').update(structureBytes).digest('hex'),
+  };
   const manifestPath = path.join(source, 'subjectDataManifest.json');
   const departmentsPath = path.join(source, 'department_constants.json');
   await Promise.all([
     fs.writeFile(path.join(source, dataFile), dataBytes),
     fs.writeFile(manifestPath, JSON.stringify(manifest)),
     fs.writeFile(departmentsPath, JSON.stringify(artifact)),
+    fs.writeFile(path.join(source, structureFile), structureBytes),
   ]);
   return {
     root,
@@ -99,6 +126,8 @@ async function fixture(overrides = {}) {
     artifact,
     manifestPath,
     departmentsPath,
+    structure,
+    structureBytes,
   };
 }
 
@@ -147,6 +176,10 @@ test('imports a fully validated Harvester generation', async () => {
       ),
       value.manifest
     );
+    assert.deepEqual(
+      await fs.readFile(path.join(value.destination, 'subject_structure.json')),
+      value.structureBytes
+    );
   } finally {
     await dispose(value);
   }
@@ -164,6 +197,38 @@ test('check validates without writing', async () => {
     await assert.rejects(fs.access(value.destination));
   } finally {
     await dispose(value);
+  }
+});
+
+test('rejects unsupported or tampered structure reports before writing', async () => {
+  const unsupported = await fixture({ structure: { schemaVersion: 2 } });
+  const tampered = await fixture();
+  try {
+    await assert.rejects(
+      importHarvesterGeneration({
+        manifestPath: unsupported.manifestPath,
+        departmentsPath: unsupported.departmentsPath,
+        destinationDataDir: unsupported.destination,
+      }),
+      /structure report does not match/
+    );
+    await fs.appendFile(
+      path.join(tampered.source, tampered.manifest.structureReport.dataFile),
+      '\n'
+    );
+    await assert.rejects(
+      importHarvesterGeneration({
+        manifestPath: tampered.manifestPath,
+        departmentsPath: tampered.departmentsPath,
+        destinationDataDir: tampered.destination,
+      }),
+      /structure report hash does not match/
+    );
+    await assert.rejects(fs.access(unsupported.destination));
+    await assert.rejects(fs.access(tampered.destination));
+  } finally {
+    await dispose(unsupported);
+    await dispose(tampered);
   }
 });
 
@@ -344,6 +409,9 @@ test('normal import re-evaluates baseline after taking the lock', async () => {
     );
     await assert.rejects(
       fs.access(path.join(value.destination, value.dataFile))
+    );
+    await assert.rejects(
+      fs.access(path.join(value.destination, 'subject_structure.json'))
     );
   } finally {
     await dispose(value);

--- a/scripts/import-harvester-generation.test.mjs
+++ b/scripts/import-harvester-generation.test.mjs
@@ -261,15 +261,16 @@ test('CLI check prints a stable no-baseline guard report', async () => {
 test('review changes require acknowledgement while check remains write-free', async () => {
   const value = await fixture();
   try {
-    await writeBaseline(value, subjectData('2026年度'));
-    const baselinePath = path.join(value.destination, 'baseline.json');
-    const baseline = JSON.parse(await fs.readFile(baselinePath, 'utf8'));
-    baseline['10000100']['開講部局'] = '旧部局';
-    await fs.writeFile(baselinePath, JSON.stringify(baseline));
+    const baseline = subjectData('2026年度');
+    baseline['10000200'] = {
+      ...baseline['10000100'],
+      講義コード: '10000200',
+    };
+    await writeBaseline(value, baseline);
     const guard = JSON.parse(
       await fs.readFile('data/updateGuard.json', 'utf8')
     );
-    guard.fields['開講部局'].hardMinUniqueRetention = 0;
+    guard.subjectCount.hardMinRatio = 0.4;
     const guardPath = path.join(value.root, 'updateGuard.json');
     await fs.writeFile(guardPath, JSON.stringify(guard));
     const checked = await importHarvesterGeneration({
@@ -299,7 +300,7 @@ test('review changes require acknowledgement while check remains write-free', as
       (error) =>
         error.code === 1 &&
         /Update guard review required:/.test(error.stderr) &&
-        /旧部局/.test(error.stderr)
+        /subject count ratio/.test(error.stderr)
     );
     await assert.rejects(
       importHarvesterGeneration({

--- a/scripts/update-guard.mjs
+++ b/scripts/update-guard.mjs
@@ -115,6 +115,7 @@ export function evaluateUpdateGuard(baseline, incoming, config) {
   const incomingCodes = new Set(Object.keys(incoming));
   const hardFailures = [];
   const review = [];
+  const analysis = [];
   if (ratio < config.subjectCount.hardMinRatio)
     hardFailures.push(
       `subject count ratio ${ratio.toFixed(6)} is below ${config.subjectCount.hardMinRatio}`
@@ -149,13 +150,13 @@ export function evaluateUpdateGuard(baseline, incoming, config) {
         `${field} empty rate ${emptyRate.toFixed(6)} exceeds ${rule.hardMaxEmptyRate}`
       );
     if (retention < rule.hardMinUniqueRetention)
-      hardFailures.push(
+      analysis.push(
         `${field} unique retention ${retention.toFixed(6)} is below ${rule.hardMinUniqueRetention}`
       );
     if (rule.reviewAdded && added.length)
-      review.push(`${field} added values: ${added.join(', ')}`);
+      analysis.push(`${field} added values: ${added.join(', ')}`);
     if (rule.reviewRemoved && removed.length)
-      review.push(`${field} removed values: ${removed.join(', ')}`);
+      analysis.push(`${field} removed values: ${removed.join(', ')}`);
     if (
       emptyRate > 0 &&
       (baselineEmptyRate === 0 ||
@@ -188,6 +189,7 @@ export function evaluateUpdateGuard(baseline, incoming, config) {
       (code) => !incomingCodes.has(code)
     ).length,
     fields,
+    analysis,
     hardFailures,
     review,
     info: [],

--- a/scripts/update-guard.test.mjs
+++ b/scripts/update-guard.test.mjs
@@ -19,7 +19,7 @@ const subject = (code, values = {}) => [
   },
 ];
 
-test('known 2025 to 2026 change passes hard guard and reports expected review', async () => {
+test('known 2025 to 2026 change reports value-set analysis without blocking', async () => {
   const baseline = JSON.parse(
     await fs.readFile('data/subject_details_main_2025-04-03.json', 'utf8')
   );
@@ -31,15 +31,16 @@ test('known 2025 to 2026 change passes hard guard and reports expected review', 
   assert.equal(report.incomingSubjectCount, 12489);
   assert.equal(report.subjectCountDelta, 500);
   assert.equal(report.hardFailures.length, 0);
+  assert.equal(report.review.length, 0);
   assert.ok(
-    report.review.some((item) => item.includes('開講部局 added values'))
+    report.analysis.some((item) => item.includes('開講部局 added values'))
   );
   assert.ok(
-    report.review.some((item) => item.includes('教育学研究科博士課程後期'))
+    report.analysis.some((item) => item.includes('教育学研究科博士課程後期'))
   );
 });
 
-test('hard-fails truncation, excessive empty rates, and unique retention loss', () => {
+test('hard-fails truncation and excessive empty rates', () => {
   const baseline = Object.fromEntries(
     Array.from({ length: 10 }, (_, index) =>
       subject(String(index), {
@@ -61,12 +62,10 @@ test('hard-fails truncation, excessive empty rates, and unique retention loss', 
     report.hardFailures.some((item) => item.includes('subject count ratio'))
   );
   assert.ok(report.hardFailures.some((item) => item.includes('empty rate')));
-  assert.ok(
-    report.hardFailures.some((item) => item.includes('unique retention'))
-  );
+  assert.ok(report.analysis.some((item) => item.includes('unique retention')));
 });
 
-test('plausible added and removed values require review', () => {
+test('added and removed values are analysis rather than review', () => {
   const baseline = Object.fromEntries(
     Array.from({ length: 10 }, (_, index) =>
       subject(String(index), { 開講部局: `部局${index}` })
@@ -76,8 +75,9 @@ test('plausible added and removed values require review', () => {
   incoming['9']['開講部局'] = '新部局';
   const report = evaluateUpdateGuard(baseline, incoming, config);
   assert.equal(report.hardFailures.length, 0);
-  assert.ok(report.review.some((item) => item.includes('新部局')));
-  assert.ok(report.review.some((item) => item.includes('部局9')));
+  assert.equal(report.review.length, 0);
+  assert.ok(report.analysis.some((item) => item.includes('新部局')));
+  assert.ok(report.analysis.some((item) => item.includes('部局9')));
 });
 
 test('strictly validates versioned config', () => {

--- a/scripts/validate-subject-data.mjs
+++ b/scripts/validate-subject-data.mjs
@@ -54,6 +54,29 @@ export function validateManifest(manifest) {
   ) {
     throw new Error('Manifest source must be an HTTPS URL.');
   }
+  const hasVersion = 'schemaVersion' in manifest;
+  const hasStructureReport = 'structureReport' in manifest;
+  if (hasVersion || hasStructureReport) {
+    if (manifest.schemaVersion !== 1) {
+      throw new Error('Manifest schemaVersion must be 1.');
+    }
+    const binding = manifest.structureReport;
+    if (
+      !binding ||
+      typeof binding !== 'object' ||
+      Array.isArray(binding) ||
+      Object.keys(binding).sort().join(',') !== 'dataFile,sha256' ||
+      typeof binding.dataFile !== 'string' ||
+      path.basename(binding.dataFile) !== binding.dataFile ||
+      !/^subject_structure_[A-Za-z0-9._-]+\.json$/.test(binding.dataFile) ||
+      typeof binding.sha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(binding.sha256)
+    ) {
+      throw new Error(
+        'Manifest structureReport must be a valid version 1 binding.'
+      );
+    }
+  }
 }
 
 export function validateSubjectData(data, manifest) {

--- a/scripts/validate-subject-data.test.mjs
+++ b/scripts/validate-subject-data.test.mjs
@@ -107,3 +107,19 @@ test('rejects unsafe data filenames before they are used', () => {
     /dataFile must be a JSON filename in data/
   );
 });
+
+test('accepts legacy manifests and rejects unsupported structure versions', () => {
+  validateManifest(createManifest());
+  assert.throws(
+    () =>
+      validateManifest({
+        ...createManifest(),
+        schemaVersion: 2,
+        structureReport: {
+          dataFile: 'subject_structure_generation.json',
+          sha256: 'a'.repeat(64),
+        },
+      }),
+    /schemaVersion must be 1/
+  );
+});


### PR DESCRIPTION
## 概要

- Harvesterの構造reportをschemaVersion 1として検証し、対象の科目JSONとSHA-256で結合します
- 既存の旧manifestは引き続き検証可能です
- 開講部局・科目区分・キャンパス・使用言語の集合増減は、更新を止めず `analysis` として報告します
- 件数急減・空値急増などのデータ品質guardは維持します

## 検証

- import Harvester generation: 15 tests passed
- update guard: 6 tests passed
- data validator: 8 tests passed
- subject constants: 10 tests passed
- raw subject contract: 3 tests passed
- subject diff: 9 tests passed
- TypeScript typecheck / prebuild: passed
- producer生成物からconsumer取込までの小規模結合試験: passed

関連: swawa-yu/MomijiHarvester2026#4, #99