### PR TITLE
#101 曜日・時限・講義室をbracket記法で参照する

### DIFF
--- a/src/components/TableView/ReactTableComponent.tsx
+++ b/src/components/TableView/ReactTableComponent.tsx
@@ -259,7 +259,7 @@ const ReactTableComponent: React.FC<ReactTableComponentProps> = React.memo(
         width: 160,
         sortable: false,
         renderCell: (params: GridRenderCellParams<Subject2>) => {
-          const schedules = params.row.曜日・時限・講義室.split(',');
+          const schedules = params.row['曜日・時限・講義室'].split(',');
           return (
             <Box
               sx={{


### PR DESCRIPTION
## 概要

中黒を含むフィールド名をdot記法からbracket記法へ変更し、TypeScript構文エラーを解消します。表示・型・データは変更しません。

## 検証

- Prettier: passed
- ESLint（対象ファイル）: passed
- tsc --noEmit: passed
- prebuild: passed

Closes #101