### PR TITLE
#99 分類値集合の差分artifactを生成する

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:data-validator": "node --test ./scripts/validate-subject-data.test.mjs",
     "test:raw-subject-contract": "node --test ./scripts/raw-subject-contract.test.mjs",
     "test:subject-diff": "node --test ./scripts/subject-diff.test.mjs",
+    "test:classification-diff": "node --test ./scripts/classification-diff.test.mjs",
     "lint": "eslint src --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,md,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,md,json}\"",

--- a/scripts/classification-diff.mjs
+++ b/scripts/classification-diff.mjs
@@ -1,0 +1,173 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  validateManifest,
+  validateSubjectData,
+} from './validate-subject-data.mjs';
+
+export const classificationFields = [
+  '開講部局',
+  '科目区分',
+  '開講キャンパス',
+  '使用言語',
+];
+
+const compareCodePoints = (left, right) =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+function canonicalJson(value) {
+  if (Array.isArray(value))
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort(compareCodePoints)
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function canonicalSha256(value) {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+function valueCounts(data, field) {
+  const counts = new Map();
+  let emptyCount = 0;
+  for (const subject of Object.values(data)) {
+    const value = subject[field];
+    if (value === '') emptyCount += 1;
+    else counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return {
+    values: [...counts]
+      .sort(([left], [right]) => compareCodePoints(left, right))
+      .map(([value, lectureCount]) => ({ value, lectureCount })),
+    emptyCount,
+  };
+}
+
+function snapshotMetadata(data, manifest) {
+  validateManifest(manifest);
+  validateSubjectData(data, manifest);
+  return {
+    academicYear: manifest.academicYear,
+    retrievedAt: manifest.retrievedAt,
+    subjectCount: manifest.subjectCount,
+    canonicalSha256: canonicalSha256(data),
+  };
+}
+
+export function createClassificationDiff(
+  baseline,
+  baselineManifest,
+  incoming,
+  incomingManifest
+) {
+  const base = snapshotMetadata(baseline, baselineManifest);
+  const target = snapshotMetadata(incoming, incomingManifest);
+  if (base.retrievedAt > target.retrievedAt)
+    throw new Error('Classification diff target must not predate baseline.');
+  if (
+    base.academicYear === target.academicYear &&
+    base.retrievedAt === target.retrievedAt &&
+    base.canonicalSha256 !== target.canonicalSha256
+  )
+    throw new Error(
+      'Different same-year snapshots require distinct retrievedAt values.'
+    );
+
+  const fields = {};
+  for (const field of classificationFields) {
+    const before = valueCounts(baseline, field);
+    const after = valueCounts(incoming, field);
+    const beforeMap = new Map(
+      before.values.map(({ value, lectureCount }) => [value, lectureCount])
+    );
+    const afterMap = new Map(
+      after.values.map(({ value, lectureCount }) => [value, lectureCount])
+    );
+    fields[field] = {
+      beforeUniqueCount: before.values.length,
+      afterUniqueCount: after.values.length,
+      beforeEmptyCount: before.emptyCount,
+      afterEmptyCount: after.emptyCount,
+      added: after.values.filter(({ value }) => !beforeMap.has(value)),
+      removed: before.values.filter(({ value }) => !afterMap.has(value)),
+      beforeValues: before.values,
+      afterValues: after.values,
+    };
+  }
+  return {
+    schemaVersion: 1,
+    comparisonType:
+      base.academicYear === target.academicYear
+        ? 'same-academic-year'
+        : 'academic-year-rollover',
+    base,
+    target,
+    fields,
+  };
+}
+
+export function serializeClassificationDiff(
+  baseline,
+  baselineManifest,
+  incoming,
+  incomingManifest
+) {
+  return `${JSON.stringify(
+    createClassificationDiff(
+      baseline,
+      baselineManifest,
+      incoming,
+      incomingManifest
+    ),
+    null,
+    2
+  )}\n`;
+}
+
+async function loadSnapshot(manifestPath) {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  validateManifest(manifest);
+  const data = JSON.parse(
+    await fs.readFile(
+      path.join(path.dirname(manifestPath), manifest.dataFile),
+      'utf8'
+    )
+  );
+  return { manifest, data };
+}
+
+async function main() {
+  if (process.argv.length !== 4)
+    throw new Error(
+      'Usage: node scripts/classification-diff.mjs BASELINE_MANIFEST INCOMING_MANIFEST'
+    );
+  const [baseline, incoming] = await Promise.all([
+    loadSnapshot(path.resolve(process.argv[2])),
+    loadSnapshot(path.resolve(process.argv[3])),
+  ]);
+  process.stdout.write(
+    serializeClassificationDiff(
+      baseline.data,
+      baseline.manifest,
+      incoming.data,
+      incoming.manifest
+    )
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/classification-diff.test.mjs
+++ b/scripts/classification-diff.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  canonicalSha256,
+  createClassificationDiff,
+  serializeClassificationDiff,
+} from './classification-diff.mjs';
+import { requiredFields } from './validate-subject-data.mjs';
+
+function subject(code, year, values = {}) {
+  return Object.assign(
+    Object.fromEntries(requiredFields.map((field) => [field, ''])),
+    {
+      'relative URL': `${year.slice(0, 4)}_AA_${code}.html`,
+      年度: year,
+      講義コード: code,
+      開講部局: '部局A',
+      科目区分: '科目A',
+      開講キャンパス: '東広島',
+      使用言語: 'J',
+    },
+    values
+  );
+}
+
+function manifest(data, year, retrievedAt) {
+  return {
+    dataFile: `subject_details_main_${retrievedAt}.json`,
+    academicYear: year,
+    retrievedAt,
+    subjectCount: Object.keys(data).length,
+    source: 'https://example.test/syllabus/',
+  };
+}
+
+test('reports deterministic same-year value counts without blocking semantics', () => {
+  const baseline = {
+    1: subject('1', '2026年度'),
+    2: subject('2', '2026年度', { 開講部局: '廃止部局' }),
+  };
+  const incoming = {
+    1: subject('1', '2026年度'),
+    3: subject('3', '2026年度', { 開講部局: '新部局' }),
+    4: subject('4', '2026年度', { 開講部局: '新部局' }),
+  };
+  const artifact = createClassificationDiff(
+    baseline,
+    manifest(baseline, '2026年度', '2026-04-01'),
+    incoming,
+    manifest(incoming, '2026年度', '2026-04-02')
+  );
+
+  assert.equal(artifact.schemaVersion, 1);
+  assert.equal(artifact.comparisonType, 'same-academic-year');
+  assert.deepEqual(artifact.fields['開講部局'].added, [
+    { value: '新部局', lectureCount: 2 },
+  ]);
+  assert.deepEqual(artifact.fields['開講部局'].removed, [
+    { value: '廃止部局', lectureCount: 1 },
+  ]);
+  assert.deepEqual(artifact.fields['開講部局'].afterValues, [
+    { value: '新部局', lectureCount: 2 },
+    { value: '部局A', lectureCount: 1 },
+  ]);
+  assert.equal(artifact.hardFailures, undefined);
+  assert.equal(artifact.review, undefined);
+
+  const reversed = Object.fromEntries(Object.entries(incoming).reverse());
+  assert.equal(
+    serializeClassificationDiff(
+      baseline,
+      manifest(baseline, '2026年度', '2026-04-01'),
+      incoming,
+      manifest(incoming, '2026年度', '2026-04-02')
+    ),
+    serializeClassificationDiff(
+      Object.fromEntries(Object.entries(baseline).reverse()),
+      manifest(baseline, '2026年度', '2026-04-01'),
+      reversed,
+      manifest(incoming, '2026年度', '2026-04-02')
+    )
+  );
+});
+
+test('distinguishes academic-year rollover and preserves raw values', () => {
+  const baseline = { 1: subject('1', '2026年度') };
+  const incoming = {
+    1: subject('1', '2027年度', { 開講部局: '新年度部局' }),
+  };
+  const artifact = createClassificationDiff(
+    baseline,
+    manifest(baseline, '2026年度', '2026-04-01'),
+    incoming,
+    manifest(incoming, '2027年度', '2027-04-01')
+  );
+  assert.equal(artifact.comparisonType, 'academic-year-rollover');
+  assert.deepEqual(artifact.fields['開講部局'].added, [
+    { value: '新年度部局', lectureCount: 1 },
+  ]);
+});
+
+test('matches canonical SHA-256 and real yearly classification counts', async () => {
+  const [baseline, incoming] = await Promise.all([
+    fs
+      .readFile('data/subject_details_main_2025-04-03.json', 'utf8')
+      .then(JSON.parse),
+    fs
+      .readFile('data/subject_details_main_2026-04-07.json', 'utf8')
+      .then(JSON.parse),
+  ]);
+  const artifact = createClassificationDiff(
+    baseline,
+    manifest(baseline, '2025年度', '2025-04-03'),
+    incoming,
+    manifest(incoming, '2026年度', '2026-04-07')
+  );
+
+  assert.equal(artifact.base.canonicalSha256, canonicalSha256(baseline));
+  assert.equal(artifact.target.canonicalSha256, canonicalSha256(incoming));
+  assert.equal(artifact.fields['開講部局'].beforeUniqueCount, 115);
+  assert.equal(artifact.fields['開講部局'].afterUniqueCount, 129);
+  assert.ok(
+    artifact.fields['開講部局'].added.some(
+      ({ value, lectureCount }) =>
+        value === 'スマートソサイエティ実践科学研究院博士課程前期' &&
+        lectureCount === 29
+    )
+  );
+});
+
+test('rejects malformed data and ambiguous same-date changes', () => {
+  const baseline = { 1: subject('1', '2026年度') };
+  const incoming = {
+    1: subject('1', '2026年度', { 開講部局: '変更' }),
+  };
+  assert.throws(
+    () =>
+      createClassificationDiff(
+        baseline,
+        manifest(baseline, '2026年度', '2026-04-01'),
+        incoming,
+        manifest(incoming, '2026年度', '2026-04-01')
+      ),
+    /distinct retrievedAt/
+  );
+  const broken = structuredClone(baseline);
+  delete broken['1']['科目区分'];
+  assert.throws(
+    () =>
+      createClassificationDiff(
+        broken,
+        manifest(broken, '2026年度', '2026-04-01'),
+        incoming,
+        manifest(incoming, '2026年度', '2026-04-02')
+      ),
+    /missing required field/
+  );
+});


### PR DESCRIPTION
## 概要

開講部局・科目区分・開講キャンパス・使用言語の集合変化を、更新を止めない分析artifactとして生成します。

- schemaVersion 1
- 年度内／年度切替の比較種別
- 比較元・先の年度、取得日、件数、canonical SHA-256
- fieldごとの全値と所属講義件数
- added / removedと各講義件数
- raw値と決定的順序を維持
- hard failureやreview判定を含めない純粋な分析情報

## 今回含めないもの

- update workflowへの搬送
- UI表示
- full crawl

## 検証

- classification diff: 4 tests passed（人工fixture＋2025→2026実データ）
- update guard / data validator / raw contract / subject diff: passed
- TypeScript typecheck / prebuild / diff-check: passed
- Python履歴ツールとcanonical SHA-256が一致

関連: #99
