### PR TITLE
#98 年度間の変更概要UIを追加する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import HistoryIcon from '@mui/icons-material/History';
 import InfoIcon from '@mui/icons-material/Info';
 import Alert from '@mui/material/Alert';
@@ -24,6 +25,7 @@ import HistoryDialog from './components/History/HistoryDialog';
 import SearchComponent from './components/SearchComponent';
 import TableView from './components/TableView';
 import Timetable from './components/Timetable';
+import YearlyDiffDialog from './components/YearlyDiff/YearlyDiffDialog';
 import { BookmarkProvider } from './contexts/BookmarkContext';
 import { initialSearchOptions } from './search/';
 import { subjectDataManifest } from './subject/activeSubjectData';
@@ -43,6 +45,7 @@ function App() {
   const handleInfoDialogOpen = () => setInfoDialogOpen(true);
   const handleInfoDialogClose = () => setInfoDialogOpen(false);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+  const [yearlyDiffDialogOpen, setYearlyDiffDialogOpen] = useState(false);
   const [isTimetableVisible, setIsTimetableVisible] = useState(false);
   const toggleTimetable = () => setIsTimetableVisible((prev) => !prev);
   const [tooltipOpen, setTooltipOpen] = useState(true);
@@ -84,6 +87,17 @@ function App() {
                 aria-label="同一年度内の更新履歴を開く"
               >
                 <HistoryIcon />
+              </IconButton>
+            </Tooltip>
+
+            <Tooltip title="年度間の変更概要">
+              <IconButton
+                sx={{ ml: 1 }}
+                color="inherit"
+                onClick={() => setYearlyDiffDialogOpen(true)}
+                aria-label="年度間の変更概要を開く"
+              >
+                <CompareArrowsIcon />
               </IconButton>
             </Tooltip>
 
@@ -150,6 +164,10 @@ function App() {
           open={historyDialogOpen}
           onClose={() => setHistoryDialogOpen(false)}
         />
+        <YearlyDiffDialog
+          open={yearlyDiffDialogOpen}
+          onClose={() => setYearlyDiffDialogOpen(false)}
+        />
 
         <Container
           maxWidth="xl"
@@ -210,7 +228,7 @@ function App() {
               position: 'fixed',
               bottom: { xs: 16, sm: 32 },
               right: { xs: 16, sm: 32 },
-              zIndex: (theme) => theme.zIndex.tooltip,
+              zIndex: (theme) => theme.zIndex.speedDial,
             }}
           >
             <CalendarMonthIcon />

--- a/src/components/YearlyDiff/YearlyDiffDialog.tsx
+++ b/src/components/YearlyDiff/YearlyDiffDialog.tsx
@@ -1,0 +1,105 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import { yearlyDiffSummary } from '../../subject/yearlyDiffSummary';
+
+type Props = { open: boolean; onClose: () => void };
+
+const formatDate = (value: string) => {
+  const [year, month, day] = value.split('-').map(Number);
+  return `${year}年${month}月${day}日`;
+};
+
+const countItems = (counts: Record<string, number>) =>
+  Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .sort(([, left], [, right]) => right - left);
+
+export default function YearlyDiffDialog({ open, onClose }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>年度間のシラバス変更概要</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="text.secondary">
+            年度間の同じ講義コードは比較候補であり、同一授業とは断定しません。講義コードや年度などの値はNFKC等の正規化をしていません。
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            この概要には変更前後のraw値や講義一覧は含まれないため、個別の講義diffは表示できません。最新情報はMyもみじで確認してください。
+          </Typography>
+          {yearlyDiffSummary.pairs.map((pair) => (
+            <Box
+              key={`${pair.baseline.retrievedAt}-${pair.incoming.retrievedAt}`}
+              sx={{
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 1,
+                p: 1.5,
+              }}
+            >
+              <Typography variant="h6" component="h3" gutterBottom>
+                {pair.baseline.academicYear} → {pair.incoming.academicYear}
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 1.5 }}
+              >
+                取得日：{formatDate(pair.baseline.retrievedAt)} →{' '}
+                {formatDate(pair.incoming.retrievedAt)}
+              </Typography>
+              <Grid container spacing={1} sx={{ mb: 1.5 }}>
+                <Grid item xs={12} sm={4}>
+                  <Chip
+                    label={`追加 ${pair.display.counts.added}`}
+                    color="success"
+                  />
+                </Grid>
+                <Grid item xs={12} sm={4}>
+                  <Chip
+                    label={`削除 ${pair.display.counts.removed}`}
+                    color="error"
+                  />
+                </Grid>
+                <Grid item xs={12} sm={4}>
+                  <Chip
+                    label={`内容変更 ${pair.display.counts.changed}`}
+                    color="warning"
+                  />
+                </Grid>
+              </Grid>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                年度・URLのみの変更：{pair.display.metadataOnlyChanged}件
+              </Typography>
+              <Typography variant="subtitle2">内容変更の項目別件数</Typography>
+              <Stack
+                component="ul"
+                spacing={0.25}
+                sx={{ pl: 2, mt: 0.5, mb: 0 }}
+              >
+                {countItems(pair.display.fieldChangeCounts).map(
+                  ([field, count]) => (
+                    <Typography component="li" variant="body2" key={field}>
+                      {field}：{count}件
+                    </Typography>
+                  )
+                )}
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>閉じる</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/subject/yearlyDiffSummary.ts
+++ b/src/subject/yearlyDiffSummary.ts
@@ -1,0 +1,75 @@
+import summaryJson from '../../data/yearlySubjectDiffSummary.json';
+
+export type YearlyDiffCounts = {
+  added: number;
+  removed: number;
+  changed: number;
+};
+
+export type YearlyDiffPair = {
+  baseline: { academicYear: string; retrievedAt: string };
+  incoming: { academicYear: string; retrievedAt: string };
+  display: {
+    counts: YearlyDiffCounts;
+    metadataOnlyChanged: number;
+    fieldChangeCounts: Record<string, number>;
+  };
+};
+
+export type YearlyDiffSummary = {
+  schemaVersion: 1;
+  pairs: YearlyDiffPair[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function isCounts(value: unknown): value is YearlyDiffCounts {
+  return (
+    isRecord(value) &&
+    ['added', 'removed', 'changed'].every(
+      (key) => typeof value[key] === 'number'
+    )
+  );
+}
+
+function isPair(value: unknown): value is YearlyDiffPair {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.baseline) ||
+    !isRecord(value.incoming)
+  ) {
+    return false;
+  }
+  const baseline = value.baseline;
+  const incoming = value.incoming;
+  const display = value.display;
+  return (
+    typeof baseline.academicYear === 'string' &&
+    typeof baseline.retrievedAt === 'string' &&
+    typeof incoming.academicYear === 'string' &&
+    typeof incoming.retrievedAt === 'string' &&
+    isRecord(display) &&
+    isCounts(display.counts) &&
+    typeof display.metadataOnlyChanged === 'number' &&
+    isRecord(display.fieldChangeCounts) &&
+    Object.values(display.fieldChangeCounts).every(
+      (count) => typeof count === 'number'
+    )
+  );
+}
+
+function loadSummary(value: unknown): YearlyDiffSummary {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    !Array.isArray(value.pairs) ||
+    !value.pairs.every(isPair)
+  ) {
+    throw new Error('年度間差分概要の形式が不正です。');
+  }
+  return { schemaVersion: 1, pairs: value.pairs };
+}
+
+export const yearlyDiffSummary = loadSummary(summaryJson);


### PR DESCRIPTION
## 概要

年度間diffの小さなsummary artifactを、アプリ上で確認できるダイアログへ接続します。

- AppBarに「年度間の変更概要」導線を追加
- 全年度ペアの取得日、追加、削除、内容変更を表示
- 年度・URLのみの変更を分けて表示
- 内容変更フィールドを0件除外・件数降順で表示
- 同じ講義コードを同一授業と断定しないこと、raw値・講義一覧は未収録であることを明示
- JSONのschema/runtime検証を追加
- モバイルで時間割FABがダイアログ操作を覆わないようz-indexを修正

詳細diffやbaseline JSONの新規bundleは追加していません。

## 検証

- 変更ファイル ESLint / Prettier
- `pnpm exec tsc --noEmit`
- `pnpm prebuild`
- 一時outDirへのVite production build
- `git diff --check origin/develop...HEAD`
- デスクトップ 1280x720 / モバイル 390x844 の実ブラウザ確認（導線、内容、横overflow、閉じる操作）