### PR TITLE
#98 年度間diffに異常件数の警告を追加する

### DIFF
--- a/data/yearlySubjectDiffSummary.json
+++ b/data/yearlySubjectDiffSummary.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "pairs": [
     {
       "baseline": {
@@ -70,7 +70,8 @@
           "メッセージ": 626,
           "その他": 676
         }
-      }
+      },
+      "warnings": []
     },
     {
       "baseline": {
@@ -141,7 +142,8 @@
           "メッセージ": 1082,
           "その他": 936
         }
-      }
+      },
+      "warnings": []
     }
   ]
 }

--- a/scripts/yearly-subject-diff-summary.mjs
+++ b/scripts/yearly-subject-diff-summary.mjs
@@ -11,6 +11,19 @@ import {
 
 export const defaultSummaryPath = path.join(defaultDataDir, 'yearlySubjectDiffSummary.json');
 
+// Temporary guardrails exceed the current pair maxima (about 4.7%, 17.1%,
+// 16.7%, and 68.5%) while catching large parser/year-selection anomalies.
+const WARNING_THRESHOLDS = {
+  subjectCountShift: 0.1,
+  addedRatio: 0.25,
+  removedRatio: 0.25,
+  displayChangedRatio: 0.8,
+};
+
+function warning(code, message, observed, threshold) {
+  return { code, message, observed, threshold };
+}
+
 function summarizePair(baselineEntry, incomingEntry, baseline, incoming) {
   const diff = compareSubjectData(baseline, incoming);
   const rawFieldChanges = Object.fromEntries(requiredFields.map((field) => [field, 0]));
@@ -28,6 +41,22 @@ function summarizePair(baselineEntry, incomingEntry, baseline, incoming) {
       if (kind === 'content') displayFieldChanges[field] += 1;
     }
   }
+  const added = diff.added.length;
+  const removed = diff.removed.length;
+  const commonCount = baselineEntry.subjectCount - removed;
+  const warnings = [];
+  const subjectCountShift = Math.abs(incomingEntry.subjectCount - baselineEntry.subjectCount) / baselineEntry.subjectCount;
+  if (subjectCountShift > WARNING_THRESHOLDS.subjectCountShift)
+    warnings.push(warning('subject-count-shift', '科目数の変動が閾値を超えています。', subjectCountShift, WARNING_THRESHOLDS.subjectCountShift));
+  const addedRatio = added / incomingEntry.subjectCount;
+  if (addedRatio > WARNING_THRESHOLDS.addedRatio)
+    warnings.push(warning('added-ratio', '追加科目の割合が閾値を超えています。', addedRatio, WARNING_THRESHOLDS.addedRatio));
+  const removedRatio = removed / baselineEntry.subjectCount;
+  if (removedRatio > WARNING_THRESHOLDS.removedRatio)
+    warnings.push(warning('removed-ratio', '削除科目の割合が閾値を超えています。', removedRatio, WARNING_THRESHOLDS.removedRatio));
+  const displayChangedRatio = commonCount > 0 ? displayChanged / commonCount : null;
+  if (commonCount <= 0 || displayChangedRatio > WARNING_THRESHOLDS.displayChangedRatio)
+    warnings.push(warning('display-changed-ratio', '共通科目の内容変更割合が閾値を超えています。', displayChangedRatio, WARNING_THRESHOLDS.displayChangedRatio));
   return {
     baseline: {
       academicYear: baselineEntry.academicYear,
@@ -52,6 +81,7 @@ function summarizePair(baselineEntry, incomingEntry, baseline, incoming) {
       metadataOnlyChanged,
       fieldChangeCounts: displayFieldChanges,
     },
+    warnings,
   };
 }
 
@@ -81,7 +111,7 @@ export async function generateYearlySubjectDiffSummary({
     ]);
     pairs.push(summarizePair(baselineEntry, incomingEntry, baseline, incoming));
   }
-  const expected = { schemaVersion: 1, pairs };
+  const expected = { schemaVersion: 2, pairs };
   const actual = await fs.readFile(summaryPath, 'utf8').catch((error) => {
     if (check && error.code === 'ENOENT') throw new Error(`Yearly subject diff summary is missing: ${summaryPath}`);
     if (check) throw error;

--- a/scripts/yearly-subject-diff-summary.test.mjs
+++ b/scripts/yearly-subject-diff-summary.test.mjs
@@ -53,3 +53,49 @@ test('keeps raw changes and excludes metadata-only changes from display counts',
     assert.equal(await fs.readFile(summaryPath, 'utf8'), beforeGap);
   } finally { await fs.rm(dir, { recursive: true, force: true }); }
 });
+
+test('adds deterministic warnings, including the strict threshold boundaries', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'momiji-summary-warnings-'));
+  try {
+    const files = ['subject_2024-01-01.json', 'subject_2025-01-01.json'];
+    const baseline = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2024年度'),
+    ]));
+    const incoming = Object.fromEntries(Array.from({ length: 90 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2025年度'),
+    ]));
+    // 100 baseline -> 90 incoming: 10% count shift, 0% added, 10% removed, 0% changed.
+    await fs.writeFile(path.join(dir, files[0]), JSON.stringify(baseline));
+    await fs.writeFile(path.join(dir, files[1]), JSON.stringify(incoming));
+    const { buildRegistry } = await import('./yearly-subject-baselines.mjs');
+    const registry = await buildRegistry(files, dir);
+    const registryPath = path.join(dir, 'registry.json');
+    const summaryPath = path.join(dir, 'summary.json');
+    await fs.writeFile(registryPath, JSON.stringify(registry));
+    const boundary = await generateYearlySubjectDiffSummary({ registryPath, dataDir: dir, summaryPath });
+    assert.deepEqual(boundary.pairs[0].warnings, []);
+
+    const changedIncoming = Object.fromEntries([
+      ...Object.entries(incoming),
+      ...Array.from({ length: 31 }, (_, i) => [`added-${i}`, record(`added-${i}`, '2025年度')]),
+    ]);
+    for (const [key, subject] of Object.entries(changedIncoming).slice(0, 81)) subject['授業科目名'] = `${subject['授業科目名']}-changed`;
+    await fs.writeFile(path.join(dir, files[1]), JSON.stringify(changedIncoming));
+    await fs.writeFile(registryPath, JSON.stringify(await buildRegistry(files, dir)));
+    const warnings = await generateYearlySubjectDiffSummary({ registryPath, dataDir: dir, summaryPath });
+    assert.deepEqual(warnings.pairs[0].warnings.map(({ code }) => code), [
+      'subject-count-shift', 'added-ratio', 'display-changed-ratio',
+    ]);
+
+    const noCommon = Object.fromEntries(Array.from({ length: 90 }, (_, i) => [
+      `other-${i}`, record(`other-${i}`, '2025年度'),
+    ]));
+    await fs.writeFile(path.join(dir, files[1]), JSON.stringify(noCommon));
+    await fs.writeFile(registryPath, JSON.stringify(await buildRegistry(files, dir)));
+    const noCommonSummary = await generateYearlySubjectDiffSummary({ registryPath, dataDir: dir, summaryPath });
+    assert.deepEqual(noCommonSummary.pairs[0].warnings.map(({ code }) => code), [
+      'added-ratio', 'removed-ratio', 'display-changed-ratio',
+    ]);
+    assert.equal(noCommonSummary.pairs[0].warnings[2].observed, null);
+  } finally { await fs.rm(dir, { recursive: true, force: true }); }
+});

--- a/scripts/yearly-subject-diff-summary.test.mjs
+++ b/scripts/yearly-subject-diff-summary.test.mjs
@@ -99,3 +99,53 @@ test('adds deterministic warnings, including the strict threshold boundaries', a
     assert.equal(noCommonSummary.pairs[0].warnings[2].observed, null);
   } finally { await fs.rm(dir, { recursive: true, force: true }); }
 });
+
+test('does not warn at exact added, removed, or display-change thresholds', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'momiji-summary-thresholds-'));
+  try {
+    const files = ['subject_2024-01-01.json', 'subject_2025-01-01.json'];
+    const baseline = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2024年度'),
+    ]));
+    const { buildRegistry } = await import('./yearly-subject-baselines.mjs');
+    const registryPath = path.join(dir, 'registry.json');
+    const summaryPath = path.join(dir, 'summary.json');
+    await fs.writeFile(path.join(dir, files[0]), JSON.stringify(baseline));
+
+    const writeAndSummarize = async (incoming) => {
+      await fs.writeFile(path.join(dir, files[1]), JSON.stringify(incoming));
+      await fs.writeFile(registryPath, JSON.stringify(await buildRegistry(files, dir)));
+      return generateYearlySubjectDiffSummary({ registryPath, dataDir: dir, summaryPath });
+    };
+    const warningCodes = (summary) => summary.pairs[0].warnings.map(({ code }) => code);
+
+    // Added: 25/100 = 0.25 is silent; 26/101 > 0.25 warns.
+    const addedAt = Object.fromEntries([
+      ...Array.from({ length: 75 }, (_, i) => [`base-${i}`, record(`base-${i}`, '2025年度')]),
+      ...Array.from({ length: 25 }, (_, i) => [`added-${i}`, record(`added-${i}`, '2025年度')]),
+    ]);
+    assert.equal(warningCodes(await writeAndSummarize(addedAt)).includes('added-ratio'), false);
+    const addedOver = { ...addedAt, ...Object.fromEntries([
+      ['added-over', record('added-over', '2025年度')],
+    ]) };
+    assert.equal(warningCodes(await writeAndSummarize(addedOver)).includes('added-ratio'), true);
+
+    // Removed: 25/100 = 0.25 is silent; 26/100 > 0.25 warns.
+    const removedAt = Object.fromEntries(Array.from({ length: 75 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2025年度'),
+    ]));
+    assert.equal(warningCodes(await writeAndSummarize(removedAt)).includes('removed-ratio'), false);
+    const removedOverByOne = Object.fromEntries(Array.from({ length: 74 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2025年度'),
+    ]));
+    assert.equal(warningCodes(await writeAndSummarize(removedOverByOne)).includes('removed-ratio'), true);
+
+    // Display changed: 80/100 = 0.8 is silent; 81/100 > 0.8 warns.
+    const displayAt = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [
+      `base-${i}`, record(`base-${i}`, '2025年度', i < 80 ? { 授業科目名: `changed-${i}` } : {}),
+    ]));
+    assert.equal(warningCodes(await writeAndSummarize(displayAt)).includes('display-changed-ratio'), false);
+    const displayOver = { ...displayAt, ['base-80']: record('base-80', '2025年度', { 授業科目名: 'changed-80' }) };
+    assert.equal(warningCodes(await writeAndSummarize(displayOver)).includes('display-changed-ratio'), true);
+  } finally { await fs.rm(dir, { recursive: true, force: true }); }
+});

--- a/src/components/YearlyDiff/YearlyDiffDialog.tsx
+++ b/src/components/YearlyDiff/YearlyDiffDialog.tsx
@@ -1,3 +1,4 @@
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -56,6 +57,19 @@ export default function YearlyDiffDialog({ open, onClose }: Props) {
                 取得日：{formatDate(pair.baseline.retrievedAt)} →{' '}
                 {formatDate(pair.incoming.retrievedAt)}
               </Typography>
+              {pair.warnings.length > 0 && (
+                <Stack spacing={1} sx={{ mb: 1.5 }}>
+                  {pair.warnings.map((item) => (
+                    <Alert severity="warning" key={item.code}>
+                      {item.message}（観測値：
+                      {item.observed === null
+                        ? '算出不能（共通科目なし）'
+                        : item.observed.toFixed(3)}
+                      、閾値：{item.threshold.toFixed(2)}）
+                    </Alert>
+                  ))}
+                </Stack>
+              )}
               <Grid container spacing={1} sx={{ mb: 1.5 }}>
                 <Grid item xs={12} sm={4}>
                   <Chip

--- a/src/subject/yearlyDiffSummary.ts
+++ b/src/subject/yearlyDiffSummary.ts
@@ -6,6 +6,13 @@ export type YearlyDiffCounts = {
   changed: number;
 };
 
+export type YearlyDiffWarning = {
+  code: string;
+  message: string;
+  observed: number | null;
+  threshold: number;
+};
+
 export type YearlyDiffPair = {
   baseline: { academicYear: string; retrievedAt: string };
   incoming: { academicYear: string; retrievedAt: string };
@@ -14,10 +21,11 @@ export type YearlyDiffPair = {
     metadataOnlyChanged: number;
     fieldChangeCounts: Record<string, number>;
   };
+  warnings: YearlyDiffWarning[];
 };
 
 export type YearlyDiffSummary = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   pairs: YearlyDiffPair[];
 };
 
@@ -56,6 +64,15 @@ function isPair(value: unknown): value is YearlyDiffPair {
     isRecord(display.fieldChangeCounts) &&
     Object.values(display.fieldChangeCounts).every(
       (count) => typeof count === 'number'
+    ) &&
+    Array.isArray(value.warnings) &&
+    value.warnings.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.code === 'string' &&
+        typeof item.message === 'string' &&
+        (typeof item.observed === 'number' || item.observed === null) &&
+        typeof item.threshold === 'number'
     )
   );
 }
@@ -63,13 +80,13 @@ function isPair(value: unknown): value is YearlyDiffPair {
 function loadSummary(value: unknown): YearlyDiffSummary {
   if (
     !isRecord(value) ||
-    value.schemaVersion !== 1 ||
+    value.schemaVersion !== 2 ||
     !Array.isArray(value.pairs) ||
     !value.pairs.every(isPair)
   ) {
     throw new Error('年度間差分概要の形式が不正です。');
   }
-  return { schemaVersion: 1, pairs: value.pairs };
+  return { schemaVersion: 2, pairs: value.pairs };
 }
 
 export const yearlyDiffSummary = loadSummary(summaryJson);


### PR DESCRIPTION
## 概要

年度間diffの件数が大きく変動した場合に、人間確認を促す非blockのwarningを追加します。

暫定閾値:

- 全科目数の変動: 10%超
- 追加: incomingの25%超
- 削除: baselineの25%超
- 内容変更: 共通科目の80%超（共通科目0件も警告）

閾値は現行2ペアの最大値を上回りつつ、parserや年度選択の大規模異常を拾うguardrailです。warningはbuildを失敗させず、契約・SHA・年度連続性のfail-closed検証は従来どおりです。現行2ペアはwarning 0件です。

## 検証

- 各warningの発火fixture
- 10% / 25% / 25% / 80%のexact境界では非発火、最小超過で発火
- 共通科目0件
- `pnpm test:yearly-subject-diff-summary`
- `pnpm check:yearly-subject-diff-summary`
- 変更src ESLint / Prettier
- `pnpm exec tsc --noEmit`
- `pnpm prebuild`
- 一時outDirへのVite production build
- `git diff --check origin/develop...HEAD`