### PR TITLE
#99 分類差分artifactに空値率の変化を追加する

### DIFF
--- a/scripts/classification-diff.mjs
+++ b/scripts/classification-diff.mjs
@@ -95,6 +95,11 @@ export function createClassificationDiff(
       afterUniqueCount: after.values.length,
       beforeEmptyCount: before.emptyCount,
       afterEmptyCount: after.emptyCount,
+      beforeEmptyRate: before.emptyCount / base.subjectCount,
+      afterEmptyRate: after.emptyCount / target.subjectCount,
+      emptyRateChange:
+        after.emptyCount / target.subjectCount -
+        before.emptyCount / base.subjectCount,
       added: after.values.filter(({ value }) => !beforeMap.has(value)),
       removed: before.values.filter(({ value }) => !afterMap.has(value)),
       beforeValues: before.values,
@@ -102,7 +107,7 @@ export function createClassificationDiff(
     };
   }
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     comparisonType:
       base.academicYear === target.academicYear
         ? 'same-academic-year'

--- a/scripts/classification-diff.test.mjs
+++ b/scripts/classification-diff.test.mjs
@@ -52,7 +52,7 @@ test('reports deterministic same-year value counts without blocking semantics', 
     manifest(incoming, '2026年度', '2026-04-02')
   );
 
-  assert.equal(artifact.schemaVersion, 1);
+  assert.equal(artifact.schemaVersion, 2);
   assert.equal(artifact.comparisonType, 'same-academic-year');
   assert.deepEqual(artifact.fields['開講部局'].added, [
     { value: '新部局', lectureCount: 2 },
@@ -60,6 +60,9 @@ test('reports deterministic same-year value counts without blocking semantics', 
   assert.deepEqual(artifact.fields['開講部局'].removed, [
     { value: '廃止部局', lectureCount: 1 },
   ]);
+  assert.equal(artifact.fields['開講部局'].beforeEmptyRate, 0);
+  assert.equal(artifact.fields['開講部局'].afterEmptyRate, 0);
+  assert.equal(artifact.fields['開講部局'].emptyRateChange, 0);
   assert.deepEqual(artifact.fields['開講部局'].afterValues, [
     { value: '新部局', lectureCount: 2 },
     { value: '部局A', lectureCount: 1 },
@@ -99,6 +102,45 @@ test('distinguishes academic-year rollover and preserves raw values', () => {
   assert.deepEqual(artifact.fields['開講部局'].added, [
     { value: '新年度部局', lectureCount: 1 },
   ]);
+  assert.equal(artifact.fields['開講部局'].emptyRateChange, 0);
+});
+
+test('reports empty-rate worsening, improvement, and invariance', () => {
+  const baseline = {
+    1: subject('1', '2026年度', { 使用言語: '' }),
+    2: subject('2', '2026年度'),
+  };
+  const target = {
+    1: subject('1', '2026年度', { 使用言語: '' }),
+    2: subject('2', '2026年度', { 使用言語: '' }),
+  };
+  const improved = {
+    1: subject('1', '2026年度'),
+    2: subject('2', '2026年度'),
+  };
+  const worsening = createClassificationDiff(
+    baseline,
+    manifest(baseline, '2026年度', '2026-04-01'),
+    target,
+    manifest(target, '2026年度', '2026-04-02')
+  ).fields['使用言語'];
+  const improvement = createClassificationDiff(
+    baseline,
+    manifest(baseline, '2026年度', '2026-04-01'),
+    improved,
+    manifest(improved, '2026年度', '2026-04-02')
+  ).fields['使用言語'];
+  assert.equal(worsening.emptyRateChange, 0.5);
+  assert.equal(improvement.emptyRateChange, -0.5);
+  assert.equal(
+    createClassificationDiff(
+      baseline,
+      manifest(target, '2026年度', '2026-04-02'),
+      baseline,
+      manifest(baseline, '2026年度', '2026-04-03')
+    ).fields['使用言語'].emptyRateChange,
+    0
+  );
 });
 
 test('matches canonical SHA-256 and real yearly classification counts', async () => {
@@ -121,6 +163,27 @@ test('matches canonical SHA-256 and real yearly classification counts', async ()
   assert.equal(artifact.target.canonicalSha256, canonicalSha256(incoming));
   assert.equal(artifact.fields['開講部局'].beforeUniqueCount, 115);
   assert.equal(artifact.fields['開講部局'].afterUniqueCount, 129);
+  for (const field of [
+    '開講部局',
+    '科目区分',
+    '開講キャンパス',
+    '使用言語',
+  ]) {
+    const value = artifact.fields[field];
+    assert.equal(
+      value.beforeEmptyRate,
+      value.beforeEmptyCount / Object.keys(baseline).length
+    );
+    assert.equal(
+      value.afterEmptyRate,
+      value.afterEmptyCount / Object.keys(incoming).length
+    );
+    assert.equal(
+      value.emptyRateChange,
+      value.afterEmptyCount / Object.keys(incoming).length -
+        value.beforeEmptyCount / Object.keys(baseline).length
+    );
+  }
   assert.ok(
     artifact.fields['開講部局'].added.some(
       ({ value, lectureCount }) =>

--- a/scripts/validate-history-artifacts.mjs
+++ b/scripts/validate-history-artifacts.mjs
@@ -220,8 +220,8 @@ export function validateClassificationArtifact(artifact, knownHashes) {
     ])
   )
     throw new Error('Classification artifact has an invalid contract.');
-  if (artifact.schemaVersion !== 1)
-    throw new Error('Classification artifact schemaVersion must be 1.');
+  if (artifact.schemaVersion !== 2)
+    throw new Error('Classification artifact schemaVersion must be 2.');
   const metadataKeys = historyMetadataFields.filter(
     (field) => field !== 'source'
   );
@@ -253,6 +253,9 @@ export function validateClassificationArtifact(artifact, knownHashes) {
         'afterUniqueCount',
         'beforeEmptyCount',
         'afterEmptyCount',
+        'beforeEmptyRate',
+        'afterEmptyRate',
+        'emptyRateChange',
         'added',
         'removed',
         'beforeValues',
@@ -263,7 +266,16 @@ export function validateClassificationArtifact(artifact, knownHashes) {
       !Number.isInteger(value.beforeEmptyCount) ||
       value.beforeEmptyCount < 0 ||
       !Number.isInteger(value.afterEmptyCount) ||
-      value.afterEmptyCount < 0
+      value.afterEmptyCount < 0 ||
+      !Number.isFinite(value.beforeEmptyRate) ||
+      !Number.isFinite(value.afterEmptyRate) ||
+      !Number.isFinite(value.emptyRateChange) ||
+      value.beforeEmptyRate < 0 ||
+      value.beforeEmptyRate > 1 ||
+      value.afterEmptyRate < 0 ||
+      value.afterEmptyRate > 1 ||
+      value.emptyRateChange < -1 ||
+      value.emptyRateChange > 1
     )
       throw new Error(`Classification ${field} contract is invalid.`);
     for (const key of ['added', 'removed', 'beforeValues', 'afterValues'])
@@ -279,6 +291,14 @@ export function validateClassificationArtifact(artifact, knownHashes) {
         artifact.target.subjectCount
     )
       throw new Error(`Classification ${field} unique count does not match.`);
+    if (
+      value.beforeEmptyRate !==
+        value.beforeEmptyCount / artifact.base.subjectCount ||
+      value.afterEmptyRate !==
+        value.afterEmptyCount / artifact.target.subjectCount ||
+      value.emptyRateChange !== value.afterEmptyRate - value.beforeEmptyRate
+    )
+      throw new Error(`Classification ${field} empty rates do not match.`);
     const before = new Map(
       value.beforeValues.map((item) => [item.value, item])
     );

--- a/scripts/validate-history-artifacts.test.mjs
+++ b/scripts/validate-history-artifacts.test.mjs
@@ -63,7 +63,7 @@ async function fixture() {
   };
   const artifactBytes = bytes(artifact);
   const classification = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     comparisonType: 'same-academic-year',
     base: Object.fromEntries(
       Object.entries(artifact.base).filter(([key]) => key !== 'source')
@@ -79,6 +79,9 @@ async function fixture() {
           afterUniqueCount: 1,
           beforeEmptyCount: 0,
           afterEmptyCount: 0,
+          beforeEmptyRate: 0,
+          afterEmptyRate: 0,
+          emptyRateChange: 0,
           added: [],
           removed: [],
           beforeValues: [{ value: base['1'][field], lectureCount: 1 }],

--- a/scripts/validate-history-artifacts.test.mjs
+++ b/scripts/validate-history-artifacts.test.mjs
@@ -256,3 +256,44 @@ test('rejects path escape and inconsistent classification counts', async () => {
     await fs.rm(inconsistent.root, { recursive: true, force: true });
   }
 });
+
+test('rejects classification artifacts with tampered empty rates', async () => {
+  const value = await fixture();
+  try {
+    const classificationPath = path.join(
+      value.historyDir,
+      value.classificationFile
+    );
+    const classification = JSON.parse(
+      await fs.readFile(classificationPath, 'utf8')
+    );
+    classification.fields['開講部局'].emptyRateChange = 0.25;
+    const payload = bytes(classification);
+    value.index.classificationArtifacts[0].sha256 = sha256(payload);
+    await fs.writeFile(classificationPath, payload);
+    await fs.writeFile(
+      path.join(value.historyDir, 'index.json'),
+      JSON.stringify(value.index)
+    );
+    await assert.rejects(
+      validateHistoryDataDir(value.dataDir),
+      /empty rates do not match/
+    );
+
+    classification.fields['開講部局'].emptyRateChange = 0;
+    classification.fields['開講部局'].beforeEmptyRate = 1.1;
+    const outOfRangePayload = bytes(classification);
+    value.index.classificationArtifacts[0].sha256 = sha256(outOfRangePayload);
+    await fs.writeFile(classificationPath, outOfRangePayload);
+    await fs.writeFile(
+      path.join(value.historyDir, 'index.json'),
+      JSON.stringify(value.index)
+    );
+    await assert.rejects(
+      validateHistoryDataDir(value.dataDir),
+      /Classification 開講部局 contract is invalid/
+    );
+  } finally {
+    await fs.rm(value.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

分類値集合の非阻害analysis artifactをschemaVersion 2へ更新し、件数だけでなく母数を考慮した空値率の変化を同じsummaryで確認できるようにします。

各fieldに追加:

- `beforeEmptyRate`
- `afterEmptyRate`
- `emptyRateChange`

既存の年度・取得日・件数・canonical SHA-256、added/removed、各raw値の講義件数、比較種別、決定的順序は維持します。追加値は分析情報であり、更新をblockしません。producer側はMomijiHarvester2026 PR #20でv1/v2受入済みです。

実データ 2025→2026:

- 開講部局: 0 → 0（変化0）
- 科目区分: 約0.1585% → 約0.1361%（-0.0224pt）
- 開講キャンパス: 約0.7507% → 約1.0569%（+0.3062pt）
- 使用言語: 0 → 0（変化0）

## 検証

- classification diff tests: 5 passed
- history artifact tests: 5 passed
- empty rate悪化/改善/不変
- 改ざん率・範囲外率のreject
- `pnpm validate:data`
- `pnpm prebuild`
- `pnpm exec tsc --noEmit`
- `git diff --check origin/develop...HEAD`