### PR TITLE
Harvesterの追加HTML項目を更新情報として受理する

### DIFF
--- a/scripts/import-harvester-generation.mjs
+++ b/scripts/import-harvester-generation.mjs
@@ -54,7 +54,11 @@ function validateStructureReport(report, manifest, dataSha256) {
     !isSortedUniqueStrings(report.structure.missingHeaders) ||
     report.structure.missingHeaders.length !== 0 ||
     report.structure.unknownHeaders.some(
-      (header) => !validHeaderPresence(report.structure.headerPresence[header], report.structure.subjectPageCount)
+      (header) =>
+        !validHeaderPresence(
+          report.structure.headerPresence[header],
+          report.structure.subjectPageCount
+        )
     )
   ) {
     throw new Error(
@@ -64,7 +68,10 @@ function validateStructureReport(report, manifest, dataSha256) {
 }
 
 function isSortedUniqueStrings(values) {
-  return values.every((value, index) => typeof value === 'string' && value > (values[index - 1] ?? ''));
+  return values.every(
+    (value, index) =>
+      typeof value === 'string' && value > (values[index - 1] ?? '')
+  );
 }
 
 function validHeaderPresence(value, pageCount) {
@@ -324,11 +331,7 @@ export async function importHarvesterGeneration({
   const updateGuard = await readJson(updateGuardPath, 'update guard config');
   validateUpdateGuardConfig(updateGuard);
   let guardReport = addStructureInfo(
-    await evaluateDestinationGuard(
-    destinationDataDir,
-    data,
-    updateGuard
-    ),
+    await evaluateDestinationGuard(destinationDataDir, data, updateGuard),
     structureReport.structure
   );
   enforceGuard(guardReport, check, acceptReview);

--- a/scripts/import-harvester-generation.mjs
+++ b/scripts/import-harvester-generation.mjs
@@ -52,7 +52,11 @@ function validateStructureReport(report, manifest, dataSha256) {
     typeof report.structure.headerPresence !== 'object' ||
     !isSortedUniqueStrings(report.structure.unknownHeaders) ||
     !isSortedUniqueStrings(report.structure.missingHeaders) ||
+    !isSortedUniqueStrings(report.structure.observedHeaders) ||
     report.structure.missingHeaders.length !== 0 ||
+    report.structure.unknownHeaders.some(
+      (header) => !report.structure.observedHeaders.includes(header)
+    ) ||
     report.structure.unknownHeaders.some(
       (header) =>
         !validHeaderPresence(
@@ -79,7 +83,7 @@ function validHeaderPresence(value, pageCount) {
     value &&
     typeof value === 'object' &&
     Number.isInteger(value.presentCount) &&
-    value.presentCount >= 0 &&
+    value.presentCount > 0 &&
     value.presentCount <= pageCount &&
     value.presenceRate === value.presentCount / pageCount &&
     Number.isInteger(value.emptyCount) &&

--- a/scripts/import-harvester-generation.mjs
+++ b/scripts/import-harvester-generation.mjs
@@ -46,14 +46,54 @@ function validateStructureReport(report, manifest, dataSha256) {
     !report.structure ||
     report.structure.subjectPageCount !== manifest.subjectCount ||
     !Array.isArray(report.structure.unknownHeaders) ||
-    report.structure.unknownHeaders.length !== 0 ||
     !Array.isArray(report.structure.missingHeaders) ||
-    report.structure.missingHeaders.length !== 0
+    !Array.isArray(report.structure.observedHeaders) ||
+    !report.structure.headerPresence ||
+    typeof report.structure.headerPresence !== 'object' ||
+    !isSortedUniqueStrings(report.structure.unknownHeaders) ||
+    !isSortedUniqueStrings(report.structure.missingHeaders) ||
+    report.structure.missingHeaders.length !== 0 ||
+    report.structure.unknownHeaders.some(
+      (header) => !validHeaderPresence(report.structure.headerPresence[header], report.structure.subjectPageCount)
+    )
   ) {
     throw new Error(
       'Harvester structure report does not match the generation.'
     );
   }
+}
+
+function isSortedUniqueStrings(values) {
+  return values.every((value, index) => typeof value === 'string' && value > (values[index - 1] ?? ''));
+}
+
+function validHeaderPresence(value, pageCount) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    Number.isInteger(value.presentCount) &&
+    value.presentCount >= 0 &&
+    value.presentCount <= pageCount &&
+    value.presenceRate === value.presentCount / pageCount &&
+    Number.isInteger(value.emptyCount) &&
+    value.emptyCount >= 0 &&
+    value.emptyCount <= value.presentCount &&
+    value.emptyRate === value.emptyCount / pageCount
+  );
+}
+
+function addStructureInfo(guardReport, structure) {
+  if (structure.unknownHeaders.length === 0) return guardReport;
+  return {
+    ...guardReport,
+    info: [
+      ...guardReport.info,
+      ...structure.unknownHeaders.map((header) => {
+        const presence = structure.headerPresence[header];
+        return `HTML extra header: ${header} (present ${presence.presentCount}/${structure.subjectPageCount}, empty ${presence.emptyCount}/${structure.subjectPageCount})`;
+      }),
+    ],
+  };
 }
 
 async function atomicReplace(filePath, bytes) {
@@ -283,10 +323,13 @@ export async function importHarvesterGeneration({
 
   const updateGuard = await readJson(updateGuardPath, 'update guard config');
   validateUpdateGuardConfig(updateGuard);
-  let guardReport = await evaluateDestinationGuard(
+  let guardReport = addStructureInfo(
+    await evaluateDestinationGuard(
     destinationDataDir,
     data,
     updateGuard
+    ),
+    structureReport.structure
   );
   enforceGuard(guardReport, check, acceptReview);
 
@@ -296,10 +339,9 @@ export async function importHarvesterGeneration({
   const releaseLock = await acquireLock(destinationDataDir);
   try {
     if (afterLock) await afterLock();
-    guardReport = await evaluateDestinationGuard(
-      destinationDataDir,
-      data,
-      updateGuard
+    guardReport = addStructureInfo(
+      await evaluateDestinationGuard(destinationDataDir, data, updateGuard),
+      structureReport.structure
     );
     enforceGuard(guardReport, false, acceptReview);
     let existingData;

--- a/scripts/import-harvester-generation.test.mjs
+++ b/scripts/import-harvester-generation.test.mjs
@@ -255,6 +255,30 @@ test('rejects missing headers and inconsistent unknown header presence before wr
         },
       },
     },
+    {
+      observedHeaders: fields.slice().sort(),
+      unknownHeaders: ['HTML追加項目'],
+      headerPresence: {
+        HTML追加項目: {
+          presentCount: 1,
+          presenceRate: 1,
+          emptyCount: 0,
+          emptyRate: 0,
+        },
+      },
+    },
+    {
+      observedHeaders: [...fields, 'HTML追加項目'].sort(),
+      unknownHeaders: ['HTML追加項目'],
+      headerPresence: {
+        HTML追加項目: {
+          presentCount: 0,
+          presenceRate: 0,
+          emptyCount: 0,
+          emptyRate: 0,
+        },
+      },
+    },
   ]) {
     const value = await fixture({
       structure: {

--- a/scripts/import-harvester-generation.test.mjs
+++ b/scripts/import-harvester-generation.test.mjs
@@ -209,7 +209,7 @@ test('accepts unknown headers as deterministic info in check and import', async 
         unknownHeaders: ['HTML追加項目'],
         missingHeaders: [],
         headerPresence: {
-          'HTML追加項目': {
+          HTML追加項目: {
             presentCount: 1,
             presenceRate: 1,
             emptyCount: 0,
@@ -247,7 +247,7 @@ test('rejects missing headers and inconsistent unknown header presence before wr
     {
       unknownHeaders: ['HTML追加項目'],
       headerPresence: {
-        'HTML追加項目': {
+        HTML追加項目: {
           presentCount: 1,
           presenceRate: 0,
           emptyCount: 0,

--- a/scripts/import-harvester-generation.test.mjs
+++ b/scripts/import-harvester-generation.test.mjs
@@ -200,6 +200,90 @@ test('check validates without writing', async () => {
   }
 });
 
+test('accepts unknown headers as deterministic info in check and import', async () => {
+  const value = await fixture({
+    structure: {
+      structure: {
+        subjectPageCount: 1,
+        observedHeaders: [...fields, 'HTML追加項目'].sort(),
+        unknownHeaders: ['HTML追加項目'],
+        missingHeaders: [],
+        headerPresence: {
+          'HTML追加項目': {
+            presentCount: 1,
+            presenceRate: 1,
+            emptyCount: 0,
+            emptyRate: 0,
+          },
+        },
+      },
+    },
+  });
+  try {
+    const checked = await importHarvesterGeneration({
+      manifestPath: value.manifestPath,
+      departmentsPath: value.departmentsPath,
+      destinationDataDir: value.destination,
+      check: true,
+    });
+    assert.deepEqual(checked.guardReport.info, [
+      'no baseline',
+      'HTML extra header: HTML追加項目 (present 1/1, empty 0/1)',
+    ]);
+    const imported = await importHarvesterGeneration({
+      manifestPath: value.manifestPath,
+      departmentsPath: value.departmentsPath,
+      destinationDataDir: value.destination,
+    });
+    assert.deepEqual(imported.guardReport.info, checked.guardReport.info);
+  } finally {
+    await dispose(value);
+  }
+});
+
+test('rejects missing headers and inconsistent unknown header presence before writing', async () => {
+  for (const structure of [
+    { missingHeaders: ['年度'] },
+    {
+      unknownHeaders: ['HTML追加項目'],
+      headerPresence: {
+        'HTML追加項目': {
+          presentCount: 1,
+          presenceRate: 0,
+          emptyCount: 0,
+          emptyRate: 0,
+        },
+      },
+    },
+  ]) {
+    const value = await fixture({
+      structure: {
+        structure: {
+          subjectPageCount: 1,
+          observedHeaders: fields.slice().sort(),
+          unknownHeaders: [],
+          missingHeaders: [],
+          headerPresence: {},
+          ...structure,
+        },
+      },
+    });
+    try {
+      await assert.rejects(
+        importHarvesterGeneration({
+          manifestPath: value.manifestPath,
+          departmentsPath: value.departmentsPath,
+          destinationDataDir: value.destination,
+        }),
+        /structure report does not match/
+      );
+      await assert.rejects(fs.access(value.destination));
+    } finally {
+      await dispose(value);
+    }
+  }
+});
+
 test('rejects unsupported or tampered structure reports before writing', async () => {
   const unsupported = await fixture({ structure: { schemaVersion: 2 } });
   const tampered = await fixture();


### PR DESCRIPTION
## 変更

- Harvester structure reportのunknownHeadersをfatalではなくinfoとして受理
- unknown/observed/headerPresenceの内部整合とcount/rateを厳密検証
- checkと実importの両経路で追加見出し名・出現件数・空値件数をguardReport.infoへ追加
- missingHeadersや壊れたartifactは従来どおり書込み前に拒否

## 背景

producer側でmain契約外のHTML追加項目を安全にfilterできるようにするため、consumerもschemaVersion 1のまま情報項目を受け取れる必要があります。19フィールドのraw契約は変更しません。

## 検証

- import test: 17 passed
- prebuild: pass
- raw subject contract: 3 passed
- data validator: 8 passed
- update guard: 6 passed
- Prettier / node --check / git diff --check: pass
- 独立レビュー: blocking所見なし

Related to #19