### PR TITLE
同一年度の更新履歴を検索・絞り込みできるようにする

### DIFF
--- a/src/components/History/HistoryDialog.tsx
+++ b/src/components/History/HistoryDialog.tsx
@@ -6,8 +6,14 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
 import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { useMemo, useState } from 'react';
 
 import {
   subjectHistory,
@@ -38,20 +44,107 @@ const changeColor = (change: SubjectHistoryChange) => {
 
 const displayValue = (value: string) => (value === '' ? '（空）' : value);
 
+type ChangeFilter = 'all' | SubjectHistoryChange['type'];
+
+const normalizeSearch = (value: string) => value.trim().toLocaleLowerCase();
+
 export default function HistoryDialog({ open, onClose }: Props) {
+  const [search, setSearch] = useState('');
+  const [changeFilter, setChangeFilter] = useState<ChangeFilter>('all');
+  const normalizedSearch = normalizeSearch(search);
+  const filteredHistory = useMemo(
+    () =>
+      subjectHistory
+        .map((entry) => ({
+          ...entry,
+          changes: entry.changes.filter((change) => {
+            const matchesType =
+              changeFilter === 'all' || change.type === changeFilter;
+            const searchableText = normalizeSearch(
+              [change.lectureCode, change.titleBefore, change.titleAfter]
+                .filter(Boolean)
+                .join(' ')
+            );
+            return (
+              matchesType &&
+              (normalizedSearch === '' ||
+                searchableText.includes(normalizedSearch))
+            );
+          }),
+        }))
+        .filter((entry) => entry.changes.length > 0),
+    [changeFilter, normalizedSearch]
+  );
+  const matchingChangeCount = filteredHistory.reduce(
+    (count, entry) => count + entry.changes.length,
+    0
+  );
+
+  const handleClose = () => {
+    setSearch('');
+    setChangeFilter('all');
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle>同一年度内のシラバス更新履歴</DialogTitle>
       <DialogContent dividers>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           取得時点の間で変化したrawデータを表示します。表記ゆれ等を抑制した差分ではありません。
         </Typography>
 
+        <Stack spacing={1.5} sx={{ mb: 2 }}>
+          <TextField
+            label="講義コード・科目名で検索"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            fullWidth
+            size="small"
+          />
+          <FormControl component="fieldset">
+            <RadioGroup
+              row
+              value={changeFilter}
+              onChange={(event) =>
+                setChangeFilter(event.target.value as ChangeFilter)
+              }
+              sx={{ flexWrap: 'wrap' }}
+            >
+              <FormControlLabel
+                value="all"
+                control={<Radio />}
+                label="すべて"
+              />
+              <FormControlLabel
+                value="added"
+                control={<Radio />}
+                label="追加"
+              />
+              <FormControlLabel
+                value="removed"
+                control={<Radio />}
+                label="削除"
+              />
+              <FormControlLabel
+                value="changed"
+                control={<Radio />}
+                label="変更"
+              />
+            </RadioGroup>
+          </FormControl>
+          <Typography variant="body2" aria-live="polite">
+            該当 {matchingChangeCount}件
+          </Typography>
+        </Stack>
+
         {subjectHistory.length === 0 ? (
           <Typography>同一年度内の更新履歴はまだありません。</Typography>
+        ) : filteredHistory.length === 0 ? (
+          <Typography>条件に一致する更新履歴はありません。</Typography>
         ) : (
           <Stack spacing={2}>
-            {subjectHistory.map((entry) => (
+            {filteredHistory.map((entry) => (
               <Box
                 component="details"
                 key={`${entry.academicYear}-${entry.targetRetrievedAt}`}

--- a/src/components/History/HistoryDialog.tsx
+++ b/src/components/History/HistoryDialog.tsx
@@ -243,7 +243,7 @@ export default function HistoryDialog({ open, onClose }: Props) {
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>閉じる</Button>
+        <Button onClick={handleClose}>閉じる</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
## 変更内容

- 同一年度内の履歴を講義コード・科目名で部分一致検索できるようにしました
- 「すべて / 追加 / 削除 / 変更」で種別を絞り込めるようにしました
- 該当件数と0件時の案内を表示します
- ダイアログを閉じると検索条件をリセットします

## 背景

2026年度の実履歴は追加74件・削除82件・変更835件、合計991件あります。従来は一覧を目視する必要があり、特定の講義や変更種別を探しにくい状態でした。

## 検証

- targeted ESLint
- Prettier check
- TypeScript `tsc --noEmit`
- `pnpm prebuild`
- `git diff --check`
- 実ブラウザ: 991 / 74 / 82 / 835件
- 講義コード `11025001` の検索とfield before/after表示
- 0件表示
- close/reopenで検索条件リセット
- 375px幅で横スクロールなし

Closes #30